### PR TITLE
fix: Changed combathandler.simba directory to optional directory

### DIFF
--- a/pest_control.simba
+++ b/pest_control.simba
@@ -2,7 +2,7 @@
 {$DEFINE SCRIPT_GUI}
 {$I SRL-T/osr.simba}
 {$I WaspLib/osr.simba}
-{$I WaspLib/osr/handlers/combathandler.simba}
+{$I WaspLib/optional/handlers/combathandler.simba} // By Baconadors :) 
 
 begin
   Login.PlayerIndex := 0;


### PR DESCRIPTION
combathandler.simba was moved to the optional directory is some previous update, which caused the pest control script to not work. Changing the directory in the script to the optional directory makes it work again.